### PR TITLE
Improve README with web development focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
-<h1>Hola, soy Nicolas.😎 </h1>
+# Hola, soy Nicolás 😎
 
-<h2> Acerca de Mi </h2>
-<p> Tengo 17 años y soy de Cordoba, Argentina.
-Soy Desarrollador de software, actualmente trabajando con tecnologías JavaScript, Lua, C# , Php y Sql. </p>
+## Acerca de mí
+Soy un desarrollador de software de 17 años, oriundo de Córdoba, Argentina. Trabajo principalmente con tecnologías JavaScript, Lua, C#, PHP y SQL. Me apasiona aprender continuamente y desarrollar soluciones que aporten valor.
 
+## Desarrollo web
+Me especializo en la construcción de aplicaciones web modernas:
+- Diseño de interfaces con **HTML5**, **CSS3** y frameworks de JavaScript.
+- Creación de APIs y servicios backend en **PHP** y **Node.js**.
+- Gestión de bases de datos con **MySQL** y **SQLite**.
 
+## Lenguajes y herramientas
+<div>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg" alt="JavaScript" width="40" height="40"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="PHP" width="40" height="40"/>
+  <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/lua/lua.png" alt="Lua" width="40" height="40"/>
+  <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/csharp/csharp.png" alt="C#" width="40" height="40"/>
+</div>
 
-<h3> Lenguajes </h3>
-
-- <a target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg" alt="javascript" width="40" height="40"/> </a> 
-
--  <a target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="php" width="40" height="40"/> </a> 
-
-
--  <a target="_blank"> <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/lua/lua.png" alt="Lua" width="40" height="40"/> </a> 
-
-
-
--  <a target="_blank"> <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/csharp/csharp.png" alt="C#" width="40" height="40"/> </a> 
+## Más sobre mí
+- Apasionado por el trabajo en equipo y la colaboración.
+- Siempre abierto a nuevos proyectos y retos.
+- Dispuesto a compartir conocimientos y contribuir a la comunidad de código abierto.


### PR DESCRIPTION
## Summary
- rewrite README in Spanish
- add section about web development
- restructure languages and tools icons

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850f8535b288332b03421482ffdb7c2